### PR TITLE
Upstream GeoFence fix: The filtering of GeoFence data via the GET endpoint doesn't work

### DIFF
--- a/geo_fence_operations/serializers.py
+++ b/geo_fence_operations/serializers.py
@@ -16,10 +16,8 @@ class GeoFencePropertiesSerializer(serializers.Serializer):
     name = serializers.CharField(required=False, default="Standard Geofence")
     upper_limit = serializers.IntegerField(required=False, default=500)
     lower_limit = serializers.IntegerField(required=False, default=100)
-    start_time = serializers.DateField(required=False, default=arrow.now().isoformat())
-    end_time = serializers.DateField(
-        required=False, default=arrow.now().shift(hours=1).isoformat()
-    )
+    start_time = serializers.DateField(required=False)
+    end_time = serializers.DateField(required=False)
 
 
 class GeoFenceFeatureSerializer(serializers.Serializer):

--- a/geo_fence_operations/serializers.py
+++ b/geo_fence_operations/serializers.py
@@ -1,27 +1,64 @@
-from rest_framework import serializers
 import json
+
+import arrow
+from rest_framework import serializers
+
 from .models import GeoFence
+
+
+class GeoFenceRequest:
+    def __init__(self, type, features):
+        self.type = type
+        self.features = features
+
+
+class GeoFencePropertiesSerializer(serializers.Serializer):
+    name = serializers.CharField(required=False, default="Standard Geofence")
+    upper_limit = serializers.IntegerField(required=False, default=500)
+    lower_limit = serializers.IntegerField(required=False, default=100)
+    start_time = serializers.DateField(required=False, default=arrow.now().isoformat())
+    end_time = serializers.DateField(
+        required=False, default=arrow.now().shift(hours=1).isoformat()
+    )
+
+
+class GeoFenceFeatureSerializer(serializers.Serializer):
+    type = serializers.CharField()
+    properties = GeoFencePropertiesSerializer()
+    geometry = serializers.DictField(
+        error_messages={"required": "A valid geometry object must be provided."}
+    )
+
+
+class GeoFenceRequestSerializer(serializers.Serializer):
+    type = serializers.CharField()
+    features = serializers.ListField(
+        child=GeoFenceFeatureSerializer(), min_length=1, max_length=1
+    )
+
+    def create(self, validated_data):
+        return GeoFenceRequest(**validated_data)
+
 
 class GeoFenceSerializer(serializers.ModelSerializer):
     altitude_ref = serializers.SerializerMethodField()
     raw_geo_fence = serializers.SerializerMethodField()
     geozone = serializers.SerializerMethodField()
-    
+
     def get_raw_geo_fence(self, obj):
         raw_geo_fence = json.loads(obj.raw_geo_fence)
         return raw_geo_fence
+
     def get_geozone(self, obj):
-        if obj.geozone: 
+        if obj.geozone:
             parsed_geo_zone = json.loads(obj.geozone)
-        else: 
+        else:
             parsed_geo_zone = {}
         return parsed_geo_zone
-    
+
     class Meta:
         model = GeoFence
-        fields = '__all__'
-   
-   
-    def get_altitude_ref(self,obj):
+        fields = "__all__"
+
+    def get_altitude_ref(self, obj):
         return obj.get_altitude_ref_display()
-     

--- a/geo_fence_operations/urls.py
+++ b/geo_fence_operations/urls.py
@@ -13,20 +13,20 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
 from django.urls import path
 from . import views as geo_fence_views
 
 
 urlpatterns = [
-    path('set_geo_fence', geo_fence_views.set_geo_fence),
-    path('set_geozone', geo_fence_views.set_geozone),
-    path('geo_fence', geo_fence_views.GeoFenceList.as_view()),
-    path('geo_fence/<uuid:pk>', geo_fence_views.GeoFenceDetail.as_view()),
-
+    path("set_geo_fence", geo_fence_views.set_geo_fence, name="set_geo_fence"),
+    path("set_geozone", geo_fence_views.set_geozone),
+    path("geo_fence", geo_fence_views.GeoFenceList.as_view()),
+    path("geo_fence/<uuid:pk>", geo_fence_views.GeoFenceDetail.as_view()),
     # End points for automated testing interface
-    path('geo_awareness/status', geo_fence_views.GeoZoneTestHarnessStatus.as_view()),
-    path('geo_awareness/geozone_sources/<uuid:geozone_source_id>', geo_fence_views.GeoZoneSourcesOperations.as_view()),
-    path('geo_awareness/geozones/check', geo_fence_views.GeoZoneCheck.as_view()),
-
+    path("geo_awareness/status", geo_fence_views.GeoZoneTestHarnessStatus.as_view()),
+    path(
+        "geo_awareness/geozone_sources/<uuid:geozone_source_id>",
+        geo_fence_views.GeoZoneSourcesOperations.as_view(),
+    ),
+    path("geo_awareness/geozones/check", geo_fence_views.GeoZoneCheck.as_view()),
 ]

--- a/geo_fence_operations/views.py
+++ b/geo_fence_operations/views.py
@@ -86,11 +86,16 @@ def set_geo_fence(request: HttpRequest):
     bnd_tuple = combined_features.bounds
     bounds = ",".join(["{:.7f}".format(x) for x in bnd_tuple])
 
-    s_time = feature["properties"]["start_time"]
-    start_time = arrow.get(s_time).isoformat()
-
-    e_time = feature["properties"]["end_time"]
-    end_time = arrow.get(e_time).isoformat()
+    start_time = (
+        arrow.now().isoformat()
+        if "start_time" not in feature["properties"]
+        else arrow.get(feature["properties"]["start_time"]).isoformat()
+    )
+    end_time = (
+        arrow.now().shift(hours=1).isoformat()
+        if "end_time" not in feature["properties"]
+        else arrow.get(feature["properties"]["end_time"]).isoformat()
+    )
 
     upper_limit = Decimal(feature["properties"]["upper_limit"])
     lower_limit = Decimal(feature["properties"]["lower_limit"])

--- a/geo_fence_operations/views.py
+++ b/geo_fence_operations/views.py
@@ -1,338 +1,406 @@
 # Create your views here.
-import uuid
-from auth_helper.utils import requires_scopes
+import io
+
 # Create your views here.
 import json
-import arrow
-from typing import List
-from . import rtree_geo_fence_helper
-from rest_framework.decorators import api_view
-from shapely.geometry import shape, Point
-from .models import GeoFence
-from django.http import HttpResponse
-from .tasks import write_geo_fence, write_geo_zone, download_geozone_source
-from shapely.ops import unary_union
-from rest_framework import mixins, generics
-from .serializers import GeoFenceSerializer
-from django.utils.decorators import method_decorator
-from decimal import Decimal
-from .data_definitions import GeoAwarenessTestHarnessStatus, GeoAwarenessTestStatus, GeoZoneHttpsSource, GeoZoneCheckRequestBody, GeoZoneChecksResponse, GeoZoneCheckResult, GeoZoneFilterPosition
-from django.http import JsonResponse
 import logging
-import pyproj
-from .buffer_helper import toFromUTM
-from auth_helper.common import get_redis
-from django.core.validators import URLValidator
-from django.core.exceptions import ValidationError
+import uuid
 from dataclasses import asdict, is_dataclass
-from .common import validate_geo_zone
+from decimal import Decimal
+from typing import List
 
-logger = logging.getLogger('django')
+import arrow
+import pyproj
+from auth_helper.common import get_redis
+from auth_helper.utils import requires_scopes
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.utils.decorators import method_decorator
+from rest_framework import generics, mixins, status
+from rest_framework.decorators import api_view
+from rest_framework.parsers import JSONParser
+from rest_framework.renderers import JSONRenderer
+from shapely.geometry import Point, shape
+from shapely.ops import unary_union
+
+from . import rtree_geo_fence_helper
+from .buffer_helper import toFromUTM
+from .common import validate_geo_zone
+from .data_definitions import (
+    GeoAwarenessTestHarnessStatus,
+    GeoAwarenessTestStatus,
+    GeoZoneCheckRequestBody,
+    GeoZoneCheckResult,
+    GeoZoneChecksResponse,
+    GeoZoneFilterPosition,
+    GeoZoneHttpsSource,
+)
+from .models import GeoFence
+from .serializers import GeoFenceRequestSerializer, GeoFenceSerializer
+from .tasks import download_geozone_source, write_geo_zone
+
+logger = logging.getLogger("django")
 
 
 class EnhancedJSONEncoder(json.JSONEncoder):
-        def default(self, o):
-            if is_dataclass(o):
-                return asdict(o)
-            return super().default(o)
+    def default(self, o):
+        if is_dataclass(o):
+            return asdict(o)
+        return super().default(o)
 
 
-INDEX_NAME = 'geofence_proc'
+INDEX_NAME = "geofence_proc"
 
-@api_view(['POST'])
-@requires_scopes(['blender.write'])
-def set_geo_fence(request):  
-    
+
+@api_view(["POST"])
+@requires_scopes(["blender.write"])
+def set_geo_fence(request: HttpRequest):
     try:
-        assert request.headers['Content-Type'] == 'application/json'   
-    except AssertionError as ae:     
-        msg = {"message":"Unsupported Media Type"}
-        return HttpResponse(json.dumps(msg), status=415, mimetype='application/json')
+        assert request.headers["Content-Type"] == "application/json"
+    except AssertionError:
+        msg = {"message": "Unsupported Media Type"}
+        return HttpResponse(
+            json.dumps(msg),
+            status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            content_type="application/json",
+        )
 
-    try:         
-        geo_json_fc = request.data
-    except KeyError as ke: 
-        msg = json.dumps({"message":"A geofence object is necessary in the body of the request"})        
-        return HttpResponse(msg, status=400)    
+    stream = io.BytesIO(request.body)
+    json_payload = JSONParser().parse(stream)
+
+    serializer = GeoFenceRequestSerializer(data=json_payload)
+    if not serializer.is_valid():
+        return HttpResponse(
+            JSONRenderer().render(serializer.errors),
+            status=status.HTTP_400_BAD_REQUEST,
+            content_type="application/json",
+        )
+
+    geo_fence_request = serializer.create(serializer.validated_data)
 
     shp_features = []
-    for feature in geo_json_fc['features']:
-        shp_features.append(shape(feature['geometry']))
+    for feature in geo_fence_request.features:
+        shp_features.append(shape(feature["geometry"]))
     combined_features = unary_union(shp_features)
     bnd_tuple = combined_features.bounds
-    bounds = ','.join(['{:.7f}'.format(x) for x in bnd_tuple])
-    try:
-        s_time = geo_json_fc[0]['properties']["start_time"]
-    except KeyError as ke: 
-        start_time = arrow.now().isoformat()
-    else:
-        start_time = arrow.get(s_time).isoformat()
-    
-    try:
-        e_time = geo_json_fc[0]['properties']["end_time"]
-    except KeyError as ke:
-        end_time = arrow.now().shift(hours=1).isoformat()
-    else:            
-        end_time = arrow.get(e_time).isoformat()
+    bounds = ",".join(["{:.7f}".format(x) for x in bnd_tuple])
 
-    try:
-        upper_limit = Decimal(geo_json_fc[0]['properties']["upper_limit"])
-    except KeyError as ke: 
-        upper_limit = 500.00
-    
-    try:
-        lower_limit = Decimal(geo_json_fc[0]['properties']["upper_limit"])
-    except KeyError as ke:
-        lower_limit = 100.00
-             
-    try:
-        name = geo_json_fc[0]['properties']["name"]
-    except KeyError as ke:
-        name = "Standard Geofence"
-    raw_geo_fence = json.dumps(geo_json_fc)
-    geo_f = GeoFence(raw_geo_fence = raw_geo_fence,start_datetime = start_time, end_datetime = end_time, upper_limit= upper_limit, lower_limit=lower_limit, bounds= bounds, name= name)
+    s_time = feature["properties"]["start_time"]
+    start_time = arrow.get(s_time).isoformat()
+
+    e_time = feature["properties"]["end_time"]
+    end_time = arrow.get(e_time).isoformat()
+
+    upper_limit = Decimal(feature["properties"]["upper_limit"])
+    lower_limit = Decimal(feature["properties"]["lower_limit"])
+    name = feature["properties"]["name"]
+
+    raw_geo_fence = json.dumps(json_payload)
+    geo_f = GeoFence(
+        raw_geo_fence=raw_geo_fence,
+        start_datetime=start_time,
+        end_datetime=end_time,
+        upper_limit=upper_limit,
+        lower_limit=lower_limit,
+        bounds=bounds,
+        name=name,
+    )
     geo_f.save()
 
-    op = json.dumps ({"message":"Geofence Declaration submitted", 'id':str(geo_f.id)})
-    return HttpResponse(op, status=200)
+    op = json.dumps({"message": "Geofence Declaration submitted", "id": str(geo_f.id)})
+    return HttpResponse(op, status=status.HTTP_200_OK, content_type="application/json")
 
-@api_view(['POST'])
-@requires_scopes(['blender.write'])
-def set_geozone(request):  
+
+@api_view(["POST"])
+@requires_scopes(["blender.write"])
+def set_geozone(request):
     try:
-        assert request.headers['Content-Type'] == 'application/json'   
-    except AssertionError as ae:     
-        msg = {"message":"Unsupported Media Type"}
-        return HttpResponse(json.dumps(msg), status=415, mimetype='application/json')
+        assert request.headers["Content-Type"] == "application/json"
+    except AssertionError as ae:
+        msg = {"message": "Unsupported Media Type"}
+        return HttpResponse(
+            json.dumps(msg),
+            status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            content_type="application/json",
+        )
 
-    try:         
+    try:
         geo_zone = request.data
-    except KeyError as ke: 
-        msg = json.dumps({"message":"A geozone object is necessary in the body of the request"})        
-        return HttpResponse(msg, status=400)    
-    
+    except KeyError as ke:
+        msg = json.dumps(
+            {"message": "A geozone object is necessary in the body of the request"}
+        )
+        return HttpResponse(msg, status=status.HTTP_400_BAD_REQUEST)
+
     is_geo_zone_valid = validate_geo_zone(geo_zone)
 
     if is_geo_zone_valid:
-        write_geo_zone.delay(geo_zone = json.dumps(geo_zone))
-        
+        write_geo_zone.delay(geo_zone=json.dumps(geo_zone))
+
         geo_f = uuid.uuid4()
-        op = json.dumps ({"message":"GeoZone Declaration submitted", 'id':str(geo_f)})
-        return HttpResponse(op, status=200)
+        op = json.dumps({"message": "GeoZone Declaration submitted", "id": str(geo_f)})
+        return HttpResponse(
+            op, status=status.HTTP_200_OK, content_type="application/json"
+        )
 
-    else: 
-        msg = json.dumps({"message":"A valid geozone object with a description is necessary the body of the request"})        
-        return HttpResponse(msg, status=400)   
+    else:
+        msg = json.dumps(
+            {
+                "message": "A valid geozone object with a description is necessary the body of the request"
+            }
+        )
+        return HttpResponse(
+            msg, status=status.HTTP_400_BAD_REQUEST, content_type="application/json"
+        )
 
 
-
-@method_decorator(requires_scopes(['blender.read']), name='dispatch')
-class GeoFenceDetail(mixins.RetrieveModelMixin, 
-                    generics.GenericAPIView):
-
-    queryset = GeoFence.objects.filter(is_test_dataset = False)
+@method_decorator(requires_scopes(["blender.read"]), name="dispatch")
+class GeoFenceDetail(mixins.RetrieveModelMixin, generics.GenericAPIView):
+    queryset = GeoFence.objects.filter(is_test_dataset=False)
     serializer_class = GeoFenceSerializer
 
     def get(self, request, *args, **kwargs):
         return self.retrieve(request, *args, **kwargs)
 
-@method_decorator(requires_scopes(['blender.read']), name='dispatch')
-class GeoFenceList(mixins.ListModelMixin,  
-    generics.GenericAPIView):
 
-    queryset = GeoFence.objects.filter(is_test_dataset = False)
+@method_decorator(requires_scopes(["blender.read"]), name="dispatch")
+class GeoFenceList(mixins.ListModelMixin, generics.GenericAPIView):
+    queryset = GeoFence.objects.filter(is_test_dataset=False)
     serializer_class = GeoFenceSerializer
 
-    def get_relevant_geo_fence(self,start_date, end_date,  view_port:List[float]):               
+    def get_relevant_geo_fence(self, start_date, end_date, view_port: List[float]):
         present = arrow.now()
         if start_date and end_date:
             s_date = arrow.get(start_date, "YYYY-MM-DD")
             e_date = arrow.get(end_date, "YYYY-MM-DD")
-    
-        else:             
+
+        else:
             s_date = present.shift(days=-1)
             e_date = present.shift(days=1)
 
-        all_fences_within_timelimits = GeoFence.objects.filter(start_datetime__lte = s_date.isoformat(), end_datetime__gte = e_date.isoformat())
+        all_fences_within_timelimits = GeoFence.objects.filter(
+            start_datetime__gte=s_date.isoformat(), end_datetime__lte=e_date.isoformat()
+        )
         logging.info("Found %s geofences" % len(all_fences_within_timelimits))
-        
+
         if view_port:
-            INDEX_NAME = 'geofence_idx'
-            my_rtree_helper = rtree_geo_fence_helper.GeoFenceRTreeIndexFactory(index_name = INDEX_NAME)  
-            my_rtree_helper.generate_geo_fence_index(all_fences = all_fences_within_timelimits)
-            all_relevant_fences = my_rtree_helper.check_box_intersection(view_box = view_port)
+            INDEX_NAME = "geofence_idx"
+            my_rtree_helper = rtree_geo_fence_helper.GeoFenceRTreeIndexFactory(
+                index_name=INDEX_NAME
+            )
+            my_rtree_helper.generate_geo_fence_index(
+                all_fences=all_fences_within_timelimits
+            )
+            all_relevant_fences = my_rtree_helper.check_box_intersection(
+                view_box=view_port
+            )
             relevant_id_set = []
             for i in all_relevant_fences:
-                relevant_id_set.append(i['geo_fence_id'])
+                relevant_id_set.append(i["geo_fence_id"])
 
             my_rtree_helper.clear_rtree_index()
-            filtered_relevant_fences = GeoFence.objects.filter(id__in = relevant_id_set)
-            
-        else: 
+            filtered_relevant_fences = GeoFence.objects.filter(id__in=relevant_id_set)
+
+        else:
             filtered_relevant_fences = all_fences_within_timelimits
 
         return filtered_relevant_fences
 
     def get_queryset(self):
-        start_date = self.request.query_params.get('start_date', None)
-        end_date = self.request.query_params.get('end_date', None)
+        start_date = self.request.query_params.get("start_date", None)
+        end_date = self.request.query_params.get("end_date", None)
 
-        view = self.request.query_params.get('view', None)
+        view = self.request.query_params.get("view", None)
         view_port = []
         if view:
             view_port = [float(i) for i in view.split(",")]
-        
-        responses = self.get_relevant_geo_fence(view_port= view_port,start_date= start_date, end_date= end_date)
+
+        responses = self.get_relevant_geo_fence(
+            view_port=view_port, start_date=start_date, end_date=end_date
+        )
         return responses
 
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)
 
-        
 
-@method_decorator(requires_scopes(['geo-awareness.test']), name='dispatch')
-class GeoZoneTestHarnessStatus(generics.GenericAPIView):    
-    
+@method_decorator(requires_scopes(["geo-awareness.test"]), name="dispatch")
+class GeoZoneTestHarnessStatus(generics.GenericAPIView):
     def get(self, request, *args, **kwargs):
         status = GeoAwarenessTestHarnessStatus(status="Ready", version="latest")
-        return JsonResponse(json.loads(json.dumps(status, cls=EnhancedJSONEncoder)), status=200)
+        return JsonResponse(
+            json.loads(json.dumps(status, cls=EnhancedJSONEncoder)), status=200
+        )
 
 
-@method_decorator(requires_scopes(['geo-awareness.test']), name='dispatch')
-class GeoZoneSourcesOperations(generics.GenericAPIView):    
+@method_decorator(requires_scopes(["geo-awareness.test"]), name="dispatch")
+class GeoZoneSourcesOperations(generics.GenericAPIView):
     def put(self, request, geozone_source_id):
-        r = get_redis()                
+        r = get_redis()
         try:
             geo_zone_url_details = ImplicitDict.parse(request.data, GeoZoneHttpsSource)
         except KeyError as ke:
-            ga_import_response = GeoAwarenessTestStatus(result = 'Rejected', message ="There was an error in processing the request payload, a url and format key is required for successful processing")
-            return JsonResponse(json.loads(json.dumps(ga_import_response, cls=EnhancedJSONEncoder)), status=200)
+            ga_import_response = GeoAwarenessTestStatus(
+                result="Rejected",
+                message="There was an error in processing the request payload, a url and format key is required for successful processing",
+            )
+            return JsonResponse(
+                json.loads(json.dumps(ga_import_response, cls=EnhancedJSONEncoder)),
+                status=200,
+            )
 
         url_validator = URLValidator()
         try:
             url_validator(geo_zone_url_details.https_source.url)
         except ValidationError as ve:
-            ga_import_response = GeoAwarenessTestStatus(result = 'Unsupported', message ="There was an error in the url provided")
-            return JsonResponse(json.loads(json.dumps(ga_import_response, cls=EnhancedJSONEncoder)), status=200)
+            ga_import_response = GeoAwarenessTestStatus(
+                result="Unsupported", message="There was an error in the url provided"
+            )
+            return JsonResponse(
+                json.loads(json.dumps(ga_import_response, cls=EnhancedJSONEncoder)),
+                status=200,
+            )
 
-        geoawareness_test_data_store = 'geoawarenes_test.' + str(geozone_source_id)
-        
-        ga_import_response = GeoAwarenessTestStatus(result = 'Activating', message="")
-        download_geozone_source.delay(geo_zone_url = geo_zone_url_details.https_source.url,geozone_source_id = geozone_source_id)
+        geoawareness_test_data_store = "geoawarenes_test." + str(geozone_source_id)
+
+        ga_import_response = GeoAwarenessTestStatus(result="Activating", message="")
+        download_geozone_source.delay(
+            geo_zone_url=geo_zone_url_details.https_source.url,
+            geozone_source_id=geozone_source_id,
+        )
 
         r.set(geoawareness_test_data_store, json.dumps(asdict(ga_import_response)))
-        r.expire(name = geoawareness_test_data_store, time = 3000)
+        r.expire(name=geoawareness_test_data_store, time=3000)
 
-        return JsonResponse(json.loads(json.dumps(ga_import_response, cls=EnhancedJSONEncoder)), status=200)
-                  
+        return JsonResponse(
+            json.loads(json.dumps(ga_import_response, cls=EnhancedJSONEncoder)),
+            status=200,
+        )
 
     def get(self, request, geozone_source_id):
-        geoawareness_test_data_store = 'geoawarenes_test.' + str(geozone_source_id)
-        r = get_redis()  
-        
+        geoawareness_test_data_store = "geoawarenes_test." + str(geozone_source_id)
+        r = get_redis()
+
         if r.exists(geoawareness_test_data_store):
             test_data_status = r.get(geoawareness_test_data_store)
             test_status = json.loads(test_data_status)
-            ga_test_status = GeoAwarenessTestStatus(result=test_status['result'], message="") 
-            return JsonResponse(json.loads(json.dumps(ga_test_status, cls=EnhancedJSONEncoder)), status=200)
-        else: 
+            ga_test_status = GeoAwarenessTestStatus(
+                result=test_status["result"], message=""
+            )
+            return JsonResponse(
+                json.loads(json.dumps(ga_test_status, cls=EnhancedJSONEncoder)),
+                status=200,
+            )
+        else:
             return JsonResponse({}, status=404)
 
     def delete(self, request, geozone_source_id):
-        geoawareness_test_data_store = 'geoawarenes_test.' + str(geozone_source_id)
-        r = get_redis()  
+        geoawareness_test_data_store = "geoawarenes_test." + str(geozone_source_id)
+        r = get_redis()
         if r.exists(geoawareness_test_data_store):
             # TODO: delete the test and dataset
-            all_test_geozones = GeoFence.objects.filter(is_test_dataset = 1)
-            for geozone in all_test_geozones.all(): 
+            all_test_geozones = GeoFence.objects.filter(is_test_dataset=1)
+            for geozone in all_test_geozones.all():
                 geozone.delete()
-            deletion_status = GeoAwarenessTestStatus(result='Deactivating', message="Test data has been scheduled to be deleted")
+            deletion_status = GeoAwarenessTestStatus(
+                result="Deactivating",
+                message="Test data has been scheduled to be deleted",
+            )
             r.set(geoawareness_test_data_store, json.dumps(asdict(deletion_status)))
-            return JsonResponse(json.loads(json.dumps(deletion_status, cls=EnhancedJSONEncoder)), status=200)
+            return JsonResponse(
+                json.loads(json.dumps(deletion_status, cls=EnhancedJSONEncoder)),
+                status=200,
+            )
 
         else:
             return JsonResponse({}, status=404)
 
-@method_decorator(requires_scopes(['geo-awareness.test']), name='dispatch')
+
+@method_decorator(requires_scopes(["geo-awareness.test"]), name="dispatch")
 class GeoZoneCheck(generics.GenericAPIView):
-
     def post(self, request, *args, **kwargs):
+        proj = pyproj.Proj(proj="utm", zone="54N", ellps="WGS84", datum="WGS84")
 
-        proj = pyproj.Proj(
-            proj="utm",
-            zone='54N',
-            ellps="WGS84",
-            datum="WGS84"
-        )
-
-        geo_zone_checks = ImplicitDict.parse(request.data, GeoZoneCheckRequestBody) 
+        geo_zone_checks = ImplicitDict.parse(request.data, GeoZoneCheckRequestBody)
         geo_zones_of_interest = False
         for filter_set in geo_zone_checks.checks.filterSets:
-
-            if 'position' in filter_set:
-                filter_position = ImplicitDict.parse(filter_set['position'], GeoZoneFilterPosition)
-                relevant_geo_fences = GeoFence.objects.filter(is_test_dataset = 1)
-                INDEX_NAME = 'geofence_idx'
-                my_rtree_helper = rtree_geo_fence_helper.GeoFenceRTreeIndexFactory(index_name= INDEX_NAME) 
-                # Buffer the point to get a small view port / bounds 
+            if "position" in filter_set:
+                filter_position = ImplicitDict.parse(
+                    filter_set["position"], GeoZoneFilterPosition
+                )
+                relevant_geo_fences = GeoFence.objects.filter(is_test_dataset=1)
+                INDEX_NAME = "geofence_idx"
+                my_rtree_helper = rtree_geo_fence_helper.GeoFenceRTreeIndexFactory(
+                    index_name=INDEX_NAME
+                )
+                # Buffer the point to get a small view port / bounds
                 init_point = Point(filter_position)
                 init_shape_utm = toFromUTM(init_point, proj)
                 buffer_shape_utm = init_shape_utm.buffer(1)
                 buffer_shape_lonlat = toFromUTM(buffer_shape_utm, proj, inv=True)
                 view_port = buffer_shape_lonlat.bounds
 
-                my_rtree_helper.generate_geo_fence_index(all_fences = relevant_geo_fences)
-                all_relevant_fences = my_rtree_helper.check_box_intersection(view_box = view_port)
-                my_rtree_helper.clear_rtree_index() 
+                my_rtree_helper.generate_geo_fence_index(all_fences=relevant_geo_fences)
+                all_relevant_fences = my_rtree_helper.check_box_intersection(
+                    view_box=view_port
+                )
+                my_rtree_helper.clear_rtree_index()
                 if all_relevant_fences:
                     geo_zones_of_interest = True
-                
-            if 'after' in filter_set:
-                after_query = arrow.get(filter_set['after'])
-                geo_zones_exist = GeoFence.objects.filter(start_datetime__gte = after_query, is_test_dataset = 1).exists()
+
+            if "after" in filter_set:
+                after_query = arrow.get(filter_set["after"])
+                geo_zones_exist = GeoFence.objects.filter(
+                    start_datetime__gte=after_query, is_test_dataset=1
+                ).exists()
                 if geo_zones_exist:
                     geo_zones_of_interest = True
-            if 'before' in filter_set:
-                before_query = arrow.get(filter_set['before'])
-                geo_zones_exist = GeoFence.objects.filter(before_datetime__lte = before_query, is_test_dataset = 1).exists()
+            if "before" in filter_set:
+                before_query = arrow.get(filter_set["before"])
+                geo_zones_exist = GeoFence.objects.filter(
+                    before_datetime__lte=before_query, is_test_dataset=1
+                ).exists()
                 if geo_zones_exist:
                     geo_zones_of_interest = True
-            if 'ed269' in filter_set: 
-                ed269_filter_set = filter_set['ed269']
+            if "ed269" in filter_set:
+                ed269_filter_set = filter_set["ed269"]
                 if "uSpaceClass" in ed269_filter_set:
-                    uSpace_class_to_query = ed269_filter_set['uSpaceClass']
-                    # Iterate over Geofences to see if there is a uSpace class 
+                    uSpace_class_to_query = ed269_filter_set["uSpaceClass"]
+                    # Iterate over Geofences to see if there is a uSpace class
                     geo_zones_exist = False
-                    all_geo_zones = GeoFence.objects.filter(is_test_dataset = 1)
+                    all_geo_zones = GeoFence.objects.filter(is_test_dataset=1)
                     for current_geo_zone in all_geo_zones:
-                        current_geo_zone_uSpace_class = current_geo_zone['uSpaceClass']
+                        current_geo_zone_uSpace_class = current_geo_zone["uSpaceClass"]
                         if uSpace_class_to_query == current_geo_zone_uSpace_class:
                             geo_zones_exist = True
                             break
-                        
+
                     if geo_zones_exist:
                         geo_zones_of_interest = True
 
-
                 if "acceptableRestrictions" in ed269_filter_set:
-                    acceptable_restrictions = ed269_filter_set['acceptableRestrictions']
+                    acceptable_restrictions = ed269_filter_set["acceptableRestrictions"]
                     geo_zones_exist = False
-                    all_geo_zones = GeoFence.objects.filter(is_test_dataset = 1)
+                    all_geo_zones = GeoFence.objects.filter(is_test_dataset=1)
                     for current_geo_zone in all_geo_zones:
-                        current_geo_zone_restriction = current_geo_zone['restriction']
+                        current_geo_zone_restriction = current_geo_zone["restriction"]
                         if current_geo_zone_restriction in acceptable_restrictions:
                             geo_zones_exist = True
                             break
-                        
+
                     if geo_zones_exist:
                         geo_zones_of_interest = True
-                
-        
-        if geo_zones_of_interest: 
-            geo_zone_check_result = GeoZoneCheckResult(geozone='Present')
-        else: 
-            geo_zone_check_result = GeoZoneCheckResult(geozone='Absent')
-            
 
-        geo_zone_response = GeoZoneChecksResponse(applicableGeozone =geo_zone_check_result)
-        return JsonResponse(json.loads(json.dumps(geo_zone_response, cls=EnhancedJSONEncoder)), status=200)
+        if geo_zones_of_interest:
+            geo_zone_check_result = GeoZoneCheckResult(geozone="Present")
+        else:
+            geo_zone_check_result = GeoZoneCheckResult(geozone="Absent")
+
+        geo_zone_response = GeoZoneChecksResponse(
+            applicableGeozone=geo_zone_check_result
+        )
+        return JsonResponse(
+            json.loads(json.dumps(geo_zone_response, cls=EnhancedJSONEncoder)),
+            status=200,
+        )


### PR DESCRIPTION
### Issue

- `GET /geo_fence_ops/geo_fence` endpoint returns an empty array response even though the provided filters are valid. 

- Also when the optional filters from query parameters are not provided, the endpoint should return the GeoFence objects saved between today-tomorrow timeline. That doesn’t work either.

### The root cause for these issues

- When saving new GeoFence data, some fields in the the provided JSON are not matched properly and some field validations are missing.

- When retrieving GeoFence data via GET endpoint, the start date & end date filtering is incorrect.

### Applied fixes

- Fixed `GET /geo_fence_ops/geo_fence?start_date=XXXX-XX-XX&end_date=2XXXX-XX-XX` not working properly
- Fixed `POST /geo_fence_ops/set_geo_fence` not validating the basic payload correctly.
- Fixed `POST /geo_fence_ops/set_geo_fence` always using the default values for **_GeoFence properties_** instead of the values in JSON payload
- Introduced JSON field validation via Serialisation.

### Additional comments

- Ran code block formatting via [Black](https://black.readthedocs.io/en/stable/) formatter
- Ran import sorting via [isort](https://pycqa.github.io/isort/)