### PR TITLE
Removed unwanted check for AMQP_URL in flight_declaration_operations/view

### DIFF
--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -19,7 +19,6 @@ from django.utils.decorators import method_decorator
 from .utils import OperationalIntentsConverter
 from .tasks import submit_flight_declaration_to_dss, send_operational_update_message
 from .pagination import StandardResultsSetPagination
-from os import environ as env
 
 import logging
 logger = logging.getLogger('django')
@@ -144,16 +143,15 @@ def set_flight_declaration(request):
     fo.save()
 
     flight_declaration_id = str(fo.id)   
-    amqp_connection_url = env.get('AMQP_URL', 0)
-    if amqp_connection_url:        
-        send_operational_update_message.delay(flight_declaration_id =flight_declaration_id , message_text = "Flight Declaration created..", level = 'info')
+      
+    send_operational_update_message.delay(flight_declaration_id =flight_declaration_id , message_text = "Flight Declaration created..", level = 'info')
 
     if  all_relevant_fences and all_relevant_declarations:     
         # Async submic flight declaration to DSS
         logger.info("Self deconfliction failed, this declaration cannot be sent to the DSS system..")
-        if amqp_connection_url:        
-            self_deconfliction_failed_msg = "Self deconfliction failed for operation {operation_id} did not pass self-deconfliction, there are existing operationd declared".format(operation_id = flight_declaration_id)
-            send_operational_update_message.delay(flight_declaration_id =flight_declaration_id , message_text = self_deconfliction_failed_msg, level = 'error')
+              
+        self_deconfliction_failed_msg = "Self deconfliction failed for operation {operation_id} did not pass self-deconfliction, there are existing operationd declared".format(operation_id = flight_declaration_id)
+        send_operational_update_message.delay(flight_declaration_id =flight_declaration_id , message_text = self_deconfliction_failed_msg, level = 'error')
 
     else:
         logger.info("Self deconfliction success, this declaration will be sent to the DSS system, if a DSS URL is provided..")


### PR DESCRIPTION
We don't have to explicitly check the existence of the environmental variable `AMQP_URL` inside **_flight_declaration_operations/view.py_** when executing functions from _**.tasks.py**_

This check is already in place in **_flight_declaration_operations/tasks.py_** module:

- https://github.com/openskies-sh/flight-blender/blob/master/flight_declaration_operations/tasks.py#L66