### PR TITLE
applies volume time boundaries upon transformation

### DIFF
--- a/flight_declaration_operations/utils.py
+++ b/flight_declaration_operations/utils.py
@@ -116,11 +116,19 @@ class OperationalIntentsConverter:
                 altitude_upper=Altitude(value=max_altitude, reference="W84", units="M"),
             )
 
-            volume4D = Volume4D(
-                volume=volume3D,
-                time_start=Time(format="RFC3339", value=start_datetime),
-                time_end=Time(format="RFC3339", value=end_datetime),
-            )
+            if "start_time" in feature["properties"] and "end_time" in feature["properties"]:
+                volume4D = Volume4D(
+                    volume=volume3D,
+                    time_start=Time(format="RFC3339", value=feature["properties"]["start_time"]),
+                    time_end=Time(format="RFC3339", value=feature["properties"]["end_time"]),
+                )
+            else:
+                volume4D = Volume4D(
+                    volume=volume3D,
+                    time_start=Time(format="RFC3339", value=start_datetime),
+                    time_end=Time(format="RFC3339", value=end_datetime),
+                )
+
             all_v4d.append(volume4D)
 
         


### PR DESCRIPTION
It looks like the `start_time` and `end_time` props on submitted volumes are ignored. This is how I patched my dev instance, I am curious to know if it is already implemented and I am missing something elsewhere.