### PR TITLE
fix time overlap query

### DIFF
--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -204,11 +204,11 @@ def set_flight_declaration(request):
 
     all_relevant_declarations = []
     existing_declaration_within_timelimits = FlightDeclaration.objects.filter(
-        start_datetime__lte=start_datetime, end_datetime__gte=end_datetime
+        start_datetime__lte=end_datetime, end_datetime__gte=start_datetime
     ).exists()
     if existing_declaration_within_timelimits:
         all_declarations_within_timelimits = FlightDeclaration.objects.filter(
-            start_datetime__lte=start_datetime, end_datetime__gte=end_datetime
+          start_datetime__lte=end_datetime, end_datetime__gte=start_datetime
         )
         INDEX_NAME = "flight_declaration_idx"
         my_fd_rtree_helper = FlightDeclarationRTreeIndexFactory(index_name=INDEX_NAME)


### PR DESCRIPTION
The current logic testing for `existing_declaration_within_timelimits` only returns declarations that are fully containing the submitted declaration, skipping possible conflicts; it does not account declarations that overlap (e.g. start before but ends while the declaration is ongoing).

Found some inspiration [here](https://stackoverflow.com/a/71291160) and tested manually with success. I wonder if similar shortcoming exists in other timelapse queries in the codebase.