### PR TITLE
change opint initial state depending on DSS integration

### DIFF
--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -173,7 +173,8 @@ def set_flight_declaration(request):
             meters=props["max_altitude"]["meters"], datum=props["max_altitude"]["datum"]
         )
 
-    declaration_state = 0  # Default state is Processed
+    # Default state is Processing if working with a DSS, otherwise it is Accepted
+    declaration_state = 0 if USSP_NETWORK_ENABLED else 1
 
     flight_declaration = FlightDeclarationRequest(
         features=all_features,


### PR DESCRIPTION
It looks like a newly created operational intent should default to accepted in the current logic. This seems confirmed by TII who changed it in a similar way on their fork (see [here](https://github.com/tiiuae/flight-blender/blob/aa5ef114d7d2c612be3413b15b18a3c4ed3b0ab4/flight_declaration_operations/views.py#L254)).