### PR TITLE
remove `.delay` calls for unsigned RID submission

### DIFF
--- a/flight_feed_operations/views.py
+++ b/flight_feed_operations/views.py
@@ -250,7 +250,7 @@ def set_signed_telemetry(request):
                 flight_operation = my_blender_database_reader.get_flight_declaration_by_id(flight_declaration_id=operation_id)
 
                 if flight_operation.state in [2,3,4]: # Activated, Contingent, Non-conforming 
-                    stream_rid_data_v22.delay(rid_telemetry_observations= json.dumps(unsigned_telemetry_observations))
+                    stream_rid_data_v22(rid_telemetry_observations= json.dumps(unsigned_telemetry_observations))
                 else: 
                     operation_state_incorrect_msg = {"message": "The operation ID: {operation_id} is not one of Activated, Contingent or Non-conforming states in Flight Blender, telemetry submissin will be ignored, please change the state first.".format(operation_id = operation_id)}
                     return JsonResponse(operation_state_incorrect_msg, status=400, content_type='application/json')     
@@ -320,7 +320,7 @@ def set_telemetry(request):
             flight_operation = my_blender_database_reader.get_flight_declaration_by_id(flight_declaration_id=operation_id)
 
             if flight_operation.state in [2,3,4]: # Activated, Contingent, Non-conforming 
-                stream_rid_data_v22.delay(rid_telemetry_observations= json.dumps(unsigned_telemetry_observations))
+                stream_rid_data_v22(rid_telemetry_observations= json.dumps(unsigned_telemetry_observations))
             else: 
                 operation_state_incorrect_msg = {"message": "The operation ID: {operation_id} is not one of Activated, Contingent or Non-conforming states in Flight Blender, telemetry submission will be ignored, please change the state first.".format(operation_id = operation_id)}
                 return JsonResponse(operation_state_incorrect_msg, status=400, content_type='application/json')     

--- a/rid_operations/tasks.py
+++ b/rid_operations/tasks.py
@@ -128,7 +128,7 @@ def stream_rid_data_v22(rid_telemetry_observations):
             icao_address = flight_details_id
 
             so = SingleRIDObservation(lat_dd= lat_dd, lon_dd=lon_dd, altitude_mm=altitude_mm, traffic_source= traffic_source, source_type= source_type, icao_address=icao_address, metadata= json.dumps(asdict(observation_and_metadata)))                    
-            msgid = write_incoming_air_traffic_data.delay(json.dumps(asdict(so)))  # Send a job to the task queue
+            msgid = write_incoming_air_traffic_data(json.dumps(asdict(so)))  # Send a job to the task queue
             logger.debug("Submitted observation..")                    
             logger.debug("...")
 


### PR DESCRIPTION
Something might have broken in the past: the `.delay` calls error silently, leading to bugs preventing to send RID telemetry.

This PR addresses only the path used to upload signed and unsigned RID telemetry, but if this fix is validated, I think all the occurrences should be replaced in the codebase.